### PR TITLE
Fan out metrics/index.json

### DIFF
--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -53,26 +53,9 @@ def index_json(request):
   jsonp = request.REQUEST.get('jsonp', False)
 
   def find_local_matches():
-    matches = []
-
-    for root, dirs, files in os.walk(settings.WHISPER_DIR):
-      root = root.replace(settings.WHISPER_DIR, '')
-      for basename in files:
-        if fnmatch.fnmatch(basename, '*.wsp'):
-          matches.append(os.path.join(root, basename))
-
-    for match in do_walk_rrd_dirs(settings.RRD_DIR):
-      matches.append(match)
-
-    matches = [
-      m
-      .replace('.wsp', '')
-      .replace('.rrd', '')
-      .replace('/', '.')
-      .lstrip('.')
-      for m in sorted(matches)
-    ]
-    return matches
+    with open(settings.INDEX_FILE, 'r') as f:
+      index = set([line.strip() for line in f if line])
+      return sorted(index)
 
   if len(settings.CLUSTER_SERVERS) > 1:
     matches = STORE.index()

--- a/webapp/graphite/metrics/views.py
+++ b/webapp/graphite/metrics/views.py
@@ -51,13 +51,14 @@ def do_walk_rrd_dirs(start_path, matches=None):
 
 def index_json(request):
   jsonp = request.REQUEST.get('jsonp', False)
+  local = request.REQUEST.get('local', False)
 
   def find_local_matches():
     with open(settings.INDEX_FILE, 'r') as f:
       index = set([line.strip() for line in f if line])
       return sorted(index)
 
-  if len(settings.CLUSTER_SERVERS) > 1:
+  if len(settings.CLUSTER_SERVERS) > 1 and not local:
     matches = STORE.index()
   else:
     matches = find_local_matches()

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -28,12 +28,8 @@ class RemoteStore(object):
 
   def index(self, result_queue=False):
     request = IndexRequest(self)
-    request.send()
     results = request.get_results()
-    if result_queue:
-      result_queue.put(results)
-    else:
-      return results
+    return results
 
   def fail(self):
     self.lastFailure = time.time()
@@ -89,9 +85,8 @@ class IndexRequest:
       else:
         results = []
 
-    cache.set(self.cacheKey, results, settings.REMOTE_FIND_CACHE_DURATION)
     self.cachedResults = results
-    return results
+    return self.cacheKey, results
 
 class FindRequest:
   suppressErrors = True

--- a/webapp/graphite/remote_storage.py
+++ b/webapp/graphite/remote_storage.py
@@ -29,10 +29,11 @@ class RemoteStore(object):
   def index(self, result_queue=False):
     request = IndexRequest(self)
     request.send()
+    results = request.get_results()
     if result_queue:
-      result_queue.put(request)
+      result_queue.put(results)
     else:
-      return request
+      return results
 
   def fail(self):
     self.lastFailure = time.time()
@@ -80,7 +81,7 @@ class IndexRequest:
     try:
       assert response.status == 200, "received error response %s - %s" % (response.status, response.reason)
       result_data = response.read()
-      results = unpickle.loads(result_data)
+      results = json.loads(result_data)
     except:
       self.store.fail()
       if not self.suppressErrors:

--- a/webapp/graphite/storage.py
+++ b/webapp/graphite/storage.py
@@ -102,7 +102,7 @@ class Store:
     results = []
     result_queue = Queue.Queue()
     for store in [ r for r in self.remote_stores if r.available ]:
-      thread = threading.Thread(target=store.index, args=(result_queue))
+      thread = threading.Thread(target=store.index, args=(result_queue,))
       thread.start()
       remote_indexes.append(thread)
 


### PR DESCRIPTION
Also speeds up the local search a bit for that endpoint by reading from the on-disk index file rather than trying to recurse (this is what `graphite-api` does).
